### PR TITLE
Update Run Method

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -246,6 +246,7 @@ type Runner struct {
 	ExtraIncludePath     []string // These are additional paths passed to the compiler while building
 	ExtraLibs            []string // These libraries should be either the pull path or they should be installed where ld can find them
 	FileName             string   // name of main.F90
+	ExtraFileNames       []string   // extra file names for module etc.  
 	Flags                []string
 	IncludePath          []string
 	Language             string

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -176,6 +176,10 @@ func makeCmakeFile(runner Runner) []string {
 		cmake = append(cmake, fmt.Sprintf("find_package(%q)\n", lib))
 	}
 
+  for _, file := range runner.ExtraFileNames {
+    runner.FileName = fmt.Sprintf("%s %s", runner.FileName, file)
+  }
+
 	cmake = append(cmake, fmt.Sprintf("add_executable(%s %s)\n", runner.TargetName, runner.FileName))
 
 	target_link_libs := ""


### PR DESCRIPTION
- adding an option `ExtraFileNames` to run the method. The files specified by this option are always compiled with `FileName` that is given from the command line.

The reason why I added this option is because sometimes I want to compile the main file with a fixed module file. 
I know we can select multiple fortran files in the command line. 
But if the module file is fixed, maybe this feature can save time.   

You can add the ExtraFileNames to runner.toml as follow

```toml
BuildDir = "/tmp/build/"
ExtraFileNames = ["RPSEMethods.F90"]
```

Then, easifem run hoge.F90 command compiles the hoge.F90 with RPSEMethods.F90.
(Previously, we have to do easifem run hoge.F90 RPSEMethods.F90)

