### PR TITLE
Updates in Run method

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -246,7 +246,7 @@ type Runner struct {
 	ExtraIncludePath     []string // These are additional paths passed to the compiler while building
 	ExtraLibs            []string // These libraries should be either the pull path or they should be installed where ld can find them
 	FileName             string   // name of main.F90
-	ExtraFileNames       []string   // extra file names for module etc.  
+	ExtraFileNames       []string // extra file names for module etc.
 	Flags                []string
 	IncludePath          []string
 	Language             string
@@ -256,9 +256,13 @@ type Runner struct {
 	TargetLibs           []string // These libraries are build using Cmake and Cmake can find theme
 	TargetName           string   // name of executable
 	IsExecute            bool     // If true then we do not run the executable
+	CacheClean           bool     // If true then we do not run the executable
+	ReBuild              bool     // If true then we do not run the executable
 }
 
 var noRun = false
+var cacheClean = false
+var reBuild = false
 
 const (
 	gfortranArgs        = `"-ffree-form" "-ffree-line-length-none" "-std=f2008" "-fimplicit-none"`

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -137,13 +137,13 @@ func run(filename, pwd string) error {
 //----------------------------------------------------------------------------
 
 func init() {
-	rootCmd.AddCommand(runCmd)
-	rootCmd.PersistentFlags().BoolVar(&noRun, "no-run", false,
+	runCmd.Flags().BoolVar(&noRun, "no-run", false,
 		"Only create the binary file and do not run it.")
-	rootCmd.PersistentFlags().BoolVar(&cacheClean, "cache-clean", false,
+	runCmd.Flags().BoolVar(&cacheClean, "cache-clean", false,
 		"Clean all cache files and recreate them from scratch")
-	rootCmd.PersistentFlags().BoolVar(&reBuild, "rebuild", false,
+	runCmd.Flags().BoolVar(&reBuild, "rebuild", false,
 		"Clean the build directory first and then build")
+	rootCmd.AddCommand(runCmd)
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
- adding options `CleanCache` and `ReBuild` to execute clean build in two different ways.

If `CleanCache` is true, all cache files are removed and recreated from **scratch**
(same situation as executing run method after `rm -r $builddir`).
 
On the other hand, if `ReBuild` is true, some files in the existing build directory are removed before the build process, including a binary file. 

This option is sometimes helpful. Currently, if the build fails and the previously compiled binary file is in the build directory, the run method executes the binary file without stopping at the failure of the build.  
The `ReBuild` option can prevent this event since it will remove the binary before the build.

You can check which option is passed to `cmake` command in the changed files.