### PR TITLE
Updates for Shell Completion

### DIFF
--- a/internal/clean.go
+++ b/internal/clean.go
@@ -24,7 +24,9 @@ var cleanCmd = &cobra.Command{
 		args []string,
 		toComplete string,
 	) ([]string, cobra.ShellCompDirective) {
-		return (pkgGetAllNames()), (cobra.ShellCompDirectiveDefault)
+		candidates := pkgGetAllNames()
+		candidates = append(candidates, "extpkgs")
+		return candidates, cobra.ShellCompDirectiveDefault
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// fmt.Println(easifem_banner)

--- a/internal/clean.go
+++ b/internal/clean.go
@@ -19,6 +19,13 @@ var cleanCmd = &cobra.Command{
 	Short: "remove build and install files of a pkg",
 	Long:  easifem_clean_intro,
 	Args:  cobra.MinimumNArgs(1),
+	ValidArgsFunction: func(
+		cmd *cobra.Command,
+		args []string,
+		toComplete string,
+	) ([]string, cobra.ShellCompDirective) {
+		return (pkgGetAllNames()), (cobra.ShellCompDirectiveDefault)
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// fmt.Println(easifem_banner)
 		pwd, err := os.Getwd()

--- a/internal/dev.go
+++ b/internal/dev.go
@@ -24,6 +24,13 @@ var devCmd = &cobra.Command{
 	Short: "Develop easifem components",
 	Long:  easifem_dev_intro,
 	Args:  cobra.MinimumNArgs(1),
+	ValidArgsFunction: func(
+		cmd *cobra.Command,
+		args []string,
+		toComplete string,
+	) ([]string, cobra.ShellCompDirective) {
+		return (pkgGetAllNames()), (cobra.ShellCompDirectiveDefault)
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// fmt.Println(easifem_banner)
 		pwd, err := os.Getwd()

--- a/internal/install.go
+++ b/internal/install.go
@@ -25,7 +25,9 @@ var installCmd = &cobra.Command{
 		args []string,
 		toComplete string,
 	) ([]string, cobra.ShellCompDirective) {
-		return (pkgGetAllNames()), (cobra.ShellCompDirectiveDefault)
+		candidates := pkgGetAllNames()
+		candidates = append(candidates, "easifem", "extpkgs")
+		return candidates, cobra.ShellCompDirectiveDefault
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// fmt.Println(easifem_banner)

--- a/internal/install.go
+++ b/internal/install.go
@@ -20,6 +20,13 @@ var installCmd = &cobra.Command{
 	Short: "This subcommand install one or more packages including dependencies.",
 	Long:  easifem_install_intro,
 	Args:  cobra.MinimumNArgs(1),
+	ValidArgsFunction: func(
+		cmd *cobra.Command,
+		args []string,
+		toComplete string,
+	) ([]string, cobra.ShellCompDirective) {
+		return (pkgGetAllNames()), (cobra.ShellCompDirectiveDefault)
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// fmt.Println(easifem_banner)
 		pwd, err := os.Getwd()


### PR DESCRIPTION
- adding ValidArgsFunction to clean, dev, and install commands 
- This change allows us to get shell completion for these commands 

For example, if we press tab in shell after the `easifem install `, we can get the following good completions
```fish 
> easifem install 
arpack   elasticity  lis               scalarWave  tomlf
base     fftw        md2src            sparsekit
classes  lapack95    oneDimElasticity  superlu
```
