### PR TITLE
Some improvement

### DIFF
--- a/internal/clean.go
+++ b/internal/clean.go
@@ -24,7 +24,9 @@ var cleanCmd = &cobra.Command{
 		args []string,
 		toComplete string,
 	) ([]string, cobra.ShellCompDirective) {
-		return (pkgGetAllNames()), (cobra.ShellCompDirectiveDefault)
+		candidates := pkgGetAllNames()
+		candidates = append(candidates, "extpkgs")
+		return candidates, cobra.ShellCompDirectiveDefault
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// fmt.Println(easifem_banner)

--- a/internal/clean.go
+++ b/internal/clean.go
@@ -19,6 +19,13 @@ var cleanCmd = &cobra.Command{
 	Short: "remove build and install files of a pkg",
 	Long:  easifem_clean_intro,
 	Args:  cobra.MinimumNArgs(1),
+	ValidArgsFunction: func(
+		cmd *cobra.Command,
+		args []string,
+		toComplete string,
+	) ([]string, cobra.ShellCompDirective) {
+		return (pkgGetAllNames()), (cobra.ShellCompDirectiveDefault)
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// fmt.Println(easifem_banner)
 		pwd, err := os.Getwd()

--- a/internal/dev.go
+++ b/internal/dev.go
@@ -24,6 +24,13 @@ var devCmd = &cobra.Command{
 	Short: "Develop easifem components",
 	Long:  easifem_dev_intro,
 	Args:  cobra.MinimumNArgs(1),
+	ValidArgsFunction: func(
+		cmd *cobra.Command,
+		args []string,
+		toComplete string,
+	) ([]string, cobra.ShellCompDirective) {
+		return (pkgGetAllNames()), (cobra.ShellCompDirectiveDefault)
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// fmt.Println(easifem_banner)
 		pwd, err := os.Getwd()

--- a/internal/install.go
+++ b/internal/install.go
@@ -25,7 +25,9 @@ var installCmd = &cobra.Command{
 		args []string,
 		toComplete string,
 	) ([]string, cobra.ShellCompDirective) {
-		return (pkgGetAllNames()), (cobra.ShellCompDirectiveDefault)
+		candidates := pkgGetAllNames()
+		candidates = append(candidates, "easifem", "extpkgs")
+		return candidates, cobra.ShellCompDirectiveDefault
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// fmt.Println(easifem_banner)

--- a/internal/install.go
+++ b/internal/install.go
@@ -20,6 +20,13 @@ var installCmd = &cobra.Command{
 	Short: "This subcommand install one or more packages including dependencies.",
 	Long:  easifem_install_intro,
 	Args:  cobra.MinimumNArgs(1),
+	ValidArgsFunction: func(
+		cmd *cobra.Command,
+		args []string,
+		toComplete string,
+	) ([]string, cobra.ShellCompDirective) {
+		return (pkgGetAllNames()), (cobra.ShellCompDirectiveDefault)
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// fmt.Println(easifem_banner)
 		pwd, err := os.Getwd()


### PR DESCRIPTION
This pull request enhances the CLI commands in the `easifem` project by adding shell autocompletion functionality for argument suggestions. The changes primarily involve implementing `ValidArgsFunction` for several commands to provide dynamic completions based on available package names.

### Shell Autocompletion Enhancements:

* **`clean` Command (`internal/clean.go`)**: Added a `ValidArgsFunction` to suggest package names and the special keyword `"extpkgs"` for autocompletion.
* **`dev` Command (`internal/dev.go`)**: Introduced a `ValidArgsFunction` to dynamically suggest all package names for autocompletion.
* **`install` Command (`internal/install.go`)**: Implemented a `ValidArgsFunction` to suggest package names along with `"easifem"` and `"extpkgs"` for autocompletion.